### PR TITLE
UnloadClip() 削除、ローダーファクトリ実装

### DIFF
--- a/SoundSystemPlugin_ForUnity_Project/source/SoundCache/SoundCache_Base.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundCache/SoundCache_Base.cs
@@ -11,6 +11,12 @@ namespace SoundSystem
     internal abstract class SoundCache_Base : ISoundCache
     {
         protected readonly Dictionary<string, AudioClip> cache = new();
+        private ISoundLoader loader;
+
+        internal void SetLoader(ISoundLoader l)
+        {
+            loader = l;
+        }
     
         /// <summary>
         /// 指定リソースをキャッシュから取得する<para></para>
@@ -38,7 +44,7 @@ namespace SoundSystem
             if (cache.TryGetValue(resourceAddress, out var clip))
             {
                 Log.Safe($"Remove実行:{resourceAddress}");
-                Addressables.Release(clip);
+                loader?.ReleaseClip(clip);
                 cache.Remove(resourceAddress);
             }
         }
@@ -51,7 +57,7 @@ namespace SoundSystem
             Log.Safe("ClearAll実行");
             foreach (var clip in cache.Values)
             {
-                Addressables.Release(clip);
+                loader?.ReleaseClip(clip);
             }
             cache.Clear();
         }

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundLoader/ISoundLoader.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundLoader/ISoundLoader.cs
@@ -6,7 +6,7 @@ namespace SoundSystem
     public interface ISoundLoader
     {
         UniTask<(bool success, AudioClip clip)> TryLoadClip(string resourceAddress);
-    
-        void UnloadClip(string resourceAddress);
+
+        void ReleaseClip(AudioClip clip);
     }
 }

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundLoader/SoundLoaderFactory.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundLoader/SoundLoaderFactory.cs
@@ -1,0 +1,28 @@
+namespace SoundSystem
+{
+    using System;
+
+    /// <summary>
+    /// ISoundLoader の生成を担うファクトリー
+    /// </summary>
+    public static class SoundLoaderFactory
+    {
+        public enum LoaderType
+        {
+            Addressables,
+            Resources
+        }
+
+        public static ISoundLoader Create(ISoundCache cache, LoaderType type = LoaderType.Addressables)
+        {
+            return type switch
+            {
+#if SOUND_USE_ADDRESSABLES
+                LoaderType.Addressables => new SoundLoader_Addressables(cache),
+#endif
+                LoaderType.Resources    => new SoundLoader_Resources(cache),
+                _ => throw new ArgumentOutOfRangeException(nameof(type))
+            };
+        }
+    }
+}

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundLoader/SoundLoader_Addressables.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundLoader/SoundLoader_Addressables.cs
@@ -1,3 +1,4 @@
+#if SOUND_USE_ADDRESSABLES
 namespace SoundSystem
 {
     using Cysharp.Threading.Tasks;
@@ -6,17 +7,21 @@ namespace SoundSystem
     using UnityEngine.ResourceManagement.AsyncOperations;
     
     /// <summary>
-    /// サウンドリソースのロード,アンロードを担うクラス<para></para>
+    /// サウンドリソースのロードを担うクラス<para></para>
     /// - Addressableを介してAudioClipを非同期にロード<para></para>
     /// - ロード結果をキャッシュ管理クラス(ISoundCache)に委譲
     /// </summary>
-    public class SoundLoader : ISoundLoader
+    public class SoundLoader_Addressables : ISoundLoader
     {
         private readonly ISoundCache cache;
-    
-        public SoundLoader(ISoundCache cache)
+
+        public SoundLoader_Addressables(ISoundCache cache)
         {
             this.cache = cache;
+            if (cache is SoundCache_Base baseCache)
+            {
+                baseCache.SetLoader(this);
+            }
         }
     
         public async UniTask<(bool success, AudioClip clip)> TryLoadClip(string resourceAddress)
@@ -41,10 +46,13 @@ namespace SoundSystem
             }
         }
     
-        public void UnloadClip(string resourceAddress)
+        public void ReleaseClip(AudioClip clip)
         {
-            Log.Safe($"UnloadClip実行:{resourceAddress}");
-            cache.Remove(resourceAddress);
+            if (clip != null)
+            {
+                Addressables.Release(clip);
+            }
         }
     }
 }
+#endif

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundLoader/SoundLoader_Resources.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundLoader/SoundLoader_Resources.cs
@@ -1,0 +1,50 @@
+namespace SoundSystem
+{
+    using Cysharp.Threading.Tasks;
+    using UnityEngine;
+
+    /// <summary>
+    /// Resources API を用いたサウンドロードクラス
+    /// </summary>
+    public class SoundLoader_Resources : ISoundLoader
+    {
+        private readonly ISoundCache cache;
+
+        public SoundLoader_Resources(ISoundCache cache)
+        {
+            this.cache = cache;
+            if (cache is SoundCache_Base baseCache)
+            {
+                baseCache.SetLoader(this);
+            }
+        }
+
+        public async UniTask<(bool success, AudioClip clip)> TryLoadClip(string resourceAddress)
+        {
+            Log.Safe($"TryLoadClip実行:{resourceAddress}");
+            var request = Resources.LoadAsync<AudioClip>(resourceAddress);
+            await request;
+            var clip = request.asset as AudioClip;
+            if (clip != null)
+            {
+                cache.Add(resourceAddress, clip);
+                Log.Safe($"TryLoadClip成功:{resourceAddress}");
+                return (true, clip);
+            }
+            else
+            {
+                Log.Error($"TryLoadClip失敗:{resourceAddress}");
+                cache.Remove(resourceAddress);
+                return (false, null);
+            }
+        }
+
+        public void ReleaseClip(AudioClip clip)
+        {
+            if (clip != null)
+            {
+                Resources.UnloadAsset(clip);
+            }
+        }
+    }
+}

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundSystem.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundSystem.cs
@@ -22,7 +22,9 @@ namespace SoundSystem
         private SerializedSESettingDictionary  sePresets;
     
         public SoundSystem(ISoundCache cache, IAudioSourcePool pool, AudioListener listener,
-            AudioMixer mixer, AudioMixerGroup bgmGroup, bool canLogging = true)
+            AudioMixer mixer, AudioMixerGroup bgmGroup,
+            SoundLoaderFactory.LoaderType loaderType = SoundLoaderFactory.LoaderType.Addressables,
+            bool canLogging = true)
         {
             if (canLogging)
             {
@@ -30,7 +32,7 @@ namespace SoundSystem
                 Application.quitting += () => Log.Close();
             }
     
-            var loader = new SoundLoader(cache);
+            var loader = SoundLoaderFactory.Create(cache, loaderType);
             bgm        = new(bgmGroup, loader);
             se         = new(pool, loader);
             effector   = new(listener);
@@ -38,14 +40,15 @@ namespace SoundSystem
         }
     
         public static SoundSystem CreateFromPreset(SoundPresetProperty preset, IAudioSourcePool pool,
-            AudioListener listener, AudioMixer mixer, AudioMixerGroup bgmGroup)
+            AudioListener listener, AudioMixer mixer, AudioMixerGroup bgmGroup,
+            SoundLoaderFactory.LoaderType loaderType = SoundLoaderFactory.LoaderType.Addressables)
         {
             var cache = SoundCacheFactory.Create(
                 preset.param,
                 preset.cacheType
             );
     
-            var ss = new SoundSystem(cache, pool, listener, mixer, bgmGroup);
+            var ss = new SoundSystem(cache, pool, listener, mixer, bgmGroup, loaderType);
             ss.SetPresets(preset.bgmPresets, preset.sePresets);
             return ss;
         }


### PR DESCRIPTION
## Summary
- `UnloadClip` 関数をインターフェースから削除
  - 同関数を実装クラスからも削除
  - キャッシュ破棄は `ReleaseClip` 経由に統一
- ローダーについて Addressables, Resources 版を実装
- ローダーファクトリクラスを実装
- SoundSystem コンストラクタで ISoundLoader を受け付けるように改修

------
https://chatgpt.com/codex/tasks/task_e_6857c7da97d4832a81512c0cd63c3d6e