### PR TITLE
SoundCacheFactory の修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ SoundSystemPreset -->|SEプリセット保持| SerializedSESettingDictionary
 
 ```csharp
 //手動構成の例
-var cache = SoundCacheFactory.Create(SoundCacheType.LRU, 30f);
+var cache = SoundCacheFactory.CreateLRU(30f);
 var pool  = AudioSourcePoolFactory.CreateOldestReuse(mixerGroup, 8, 32);
 var soundSystem = new SoundSystem(
     cache,
@@ -131,6 +131,7 @@ var soundSystem = new SoundSystem(
 //プリセットから生成
 var soundSystem = SoundSystem.CreateFromPreset(
     preset,
+    cache,
     pool,
     mixer,
     mixerGroup,

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundCache/SoundCacheFactory.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundCache/SoundCacheFactory.cs
@@ -1,7 +1,6 @@
 namespace SoundSystem
 {
-    using System;
-    
+
     /// <summary>
     /// ISoundCacheインスタンスを生成するファクトリークラス
     /// </summary>
@@ -15,19 +14,27 @@ namespace SoundSystem
         }
     
         /// <summary>
-        /// 指定キャッシュ方式に応じたISoundCacheインスタンスを生成する
+        /// LRU方式のキャッシュを生成する
         /// </summary>
-        /// <param name="param">方式に応じたパラメータ(秒数または最大数)</param>
-        public static ISoundCache Create(float param,
-            Type type = Type.LRU)
+        public static ISoundCache CreateLRU(float idleTimeThreshold)
         {
-            return type switch
-            {
-                Type.LRU    => new SoundCache_LRU(idleTimeThreshold: param),
-                Type.TTL    => new SoundCache_TTL(ttlSeconds: param),
-                Type.Random => new SoundCache_Random(maxCacheCount: (int)param),
-                _ => throw new ArgumentOutOfRangeException(nameof(type)),
-            };
+            return new SoundCache_LRU(idleTimeThreshold);
+        }
+
+        /// <summary>
+        /// TTL方式のキャッシュを生成する
+        /// </summary>
+        public static ISoundCache CreateTTL(float ttlSeconds)
+        {
+            return new SoundCache_TTL(ttlSeconds);
+        }
+
+        /// <summary>
+        /// ランダム削除方式のキャッシュを生成する
+        /// </summary>
+        public static ISoundCache CreateRandom(int maxCacheCount)
+        {
+            return new SoundCache_Random(maxCacheCount);
         }
     }
 }

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundSystem.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundSystem.cs
@@ -39,15 +39,10 @@ namespace SoundSystem
             this.mixer = mixer;
         }
     
-        public static SoundSystem CreateFromPreset(SoundPresetProperty preset, IAudioSourcePool pool,
-            AudioListener listener, AudioMixer mixer, AudioMixerGroup bgmGroup,
+        public static SoundSystem CreateFromPreset(SoundPresetProperty preset, ISoundCache cache,
+            IAudioSourcePool pool, AudioListener listener, AudioMixer mixer, AudioMixerGroup bgmGroup,
             SoundLoaderFactory.Type loaderType = SoundLoaderFactory.Type.Addressables)
         {
-            var cache = SoundCacheFactory.Create(
-                preset.param,
-                preset.cacheType
-            );
-    
             var ss = new SoundSystem(cache, pool, listener, mixer, bgmGroup, loaderType);
             ss.SetPresets(preset.bgmPresets, preset.sePresets);
             return ss;


### PR DESCRIPTION
## Summary
- `SoundCacheFactory` に `CreateLRU`、`CreateTTL`、`CreateRandom` 関数を追加
- `Create` 関数は削除
- プリセットからの作成時にISoundCacheを受け付けるように `SoundSystem` を更新
- READMEの使用例を調整

------
https://chatgpt.com/codex/tasks/task_e_6858236f5718832aaa51632c8eb96ff8