### PR TITLE
SEManager.cs の UTF-8 化とBOM除去

### DIFF
--- a/SoundSystemPlugin_ForUnity_Project/source/SEManager.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SEManager.cs
@@ -1,6 +1,6 @@
 namespace SoundSystem
 {
-    ﻿using UnityEngine;
+    using UnityEngine;
     using Cysharp.Threading.Tasks;
     
     /// <summary>


### PR DESCRIPTION
## Summary
- SEManager.cs を UTF-8 (BOM なし) で保存し直しました
- 行頭に混入していた BOM を削除しました

## Testing
- `dotnet build SoundSystemPlugin_ForUnity_Project.sln` *(失敗: `dotnet` が見つかりません)*

------
https://chatgpt.com/codex/tasks/task_e_6859efcb4674832aa423d1bd90e629f2