### PR TITLE
SoundSystem にキャッシュと自動削除機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,22 +120,26 @@ SoundSystemPreset -->|SEプリセット保持| SerializedSESettingDictionary
 ```csharp
 //手動構成の例
 var cache = SoundCacheFactory.CreateLRU(30f);
-var pool  = AudioSourcePoolFactory.CreateOldestReuse(mixerGroup, 8, 32);
+var loader = SoundLoaderFactory.Create(cache, SoundLoaderFactory.Type.Addressables);
+var pool   = AudioSourcePoolFactory.CreateOldestReuse(mixerGroup, 8, 32);
 var soundSystem = new SoundSystem(
+    loader,
     cache,
     pool,
+    listener,
     mixer,
-    mixerGroup,
-    SoundLoaderFactory.LoaderType.Addressables);
+    mixerGroup);
+soundSystem.StartAutoEvict(60f);
+//利用終了時
+soundSystem.Dispose();
 
 //プリセットから生成
 var soundSystem = SoundSystem.CreateFromPreset(
     preset,
-    cache,
-    pool,
-    mixer,
-    mixerGroup,
-    SoundLoaderFactory.LoaderType.Addressables);
+    listener,
+    mixer);
+soundSystem.StartAutoEvict(60f);
+soundSystem.Dispose();
 ```
 
 ## 基本的な使い方


### PR DESCRIPTION
## 概要
- `SoundSystem` クラスで `ISoundCache` を保持するようフィールド追加
- コンストラクタを `ISoundCache cache` 引数付きに変更
- `CreateFromPreset` から生成する際にキャッシュを渡すよう更新
- 自動削除処理 `StartAutoEvict`, `StopAutoEvict` を実装
- `Dispose` で自動削除停止とログ終了を実行
- README の使用例を最新仕様に合わせて更新

------
https://chatgpt.com/codex/tasks/task_e_685a01d017b0832a87c961436eee3ebe