### PR TITLE
サウンドローダーのAddressables依存設定を切替可能に修正

### DIFF
--- a/SoundSystemPlugin_ForUnity_Project/source/SoundLoader/SoundLoaderFactory.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundLoader/SoundLoaderFactory.cs
@@ -9,7 +9,9 @@ namespace SoundSystem
     {
         public enum Type
         {
+#if USE_ADDRESSABLES
             Addressables,
+#endif
             Resources
         }
 

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundPreset/SoundPresetProperty.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundPreset/SoundPresetProperty.cs
@@ -35,7 +35,11 @@ namespace SoundSystem
         public SerializedSESettingDictionary sePresets = new();
 
         [Header("SoundLoader設定")]
+#if USE_ADDRESSABLES
         public SoundLoaderFactory.Type loaderType = SoundLoaderFactory.Type.Addressables;
+#else
+        public SoundLoaderFactory.Type loaderType = SoundLoaderFactory.Type.Resources;
+#endif
 
         [Header("SoundCache設定")]
         public SoundCacheFactory.Type cacheType = SoundCacheFactory.Type.LRU;


### PR DESCRIPTION
## 概要
- `SoundLoaderFactory.Type` を `USE_ADDRESSABLES` 定義に合わせて切り替え
- `SoundPresetProperty` の初期値も同条件で変更

------
https://chatgpt.com/codex/tasks/task_e_685abcf1b1b4832aa2263b7925c900aa