### PR TITLE
シーン変更時の自動Dispose機能追加

### DIFF
--- a/SoundSystemPlugin_ForUnity_Project/source/SoundSystem.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundSystem.cs
@@ -5,6 +5,7 @@ namespace SoundSystem
     using System.Threading;
     using UnityEngine;
     using UnityEngine.Audio;
+    using UnityEngine.SceneManagement;
     
     /// <summary>
     /// サウンド管理のエントリーポイントを提供するクラス<para></para>
@@ -26,6 +27,7 @@ namespace SoundSystem
 
         private readonly ISoundCache cache;
         private CancellationTokenSource autoEvictCTS;
+        private bool autoDisposeOnSceneChange;
 
         public SoundSystem(ISoundLoader loader, ISoundCache cache, IAudioSourcePool pool,
             AudioListener listener, AudioMixer mixer, AudioMixerGroup bgmGroup,
@@ -241,6 +243,31 @@ namespace SoundSystem
         }
         #endregion
 
+        #region AutoDispose
+
+        public void EnableAutoDisposeOnSceneChange()
+        {
+            if (autoDisposeOnSceneChange) return;
+
+            SceneManager.activeSceneChanged += OnActiveSceneChanged;
+            autoDisposeOnSceneChange = true;
+        }
+
+        public void DisableAutoDisposeOnSceneChange()
+        {
+            if (autoDisposeOnSceneChange == false) return;
+
+            SceneManager.activeSceneChanged -= OnActiveSceneChanged;
+            autoDisposeOnSceneChange = false;
+        }
+
+        private void OnActiveSceneChanged(Scene current, Scene next)
+        {
+            Dispose();
+        }
+
+        #endregion
+
         #region AutoEvict
 
         public void StartAutoEvict(float interval)
@@ -278,6 +305,7 @@ namespace SoundSystem
 
         public void Dispose()
         {
+            DisableAutoDisposeOnSceneChange();
             StopAutoEvict();
             bgm.Dispose();
             se.Dispose();


### PR DESCRIPTION
## 概要
- `SoundSystem` にシーン変更検知で自動 `Dispose` する機能を追加
- シーン遷移ごとにイベント登録を解除し多重呼び出しを防止

## 変更内容
- `EnableAutoDisposeOnSceneChange()`, `DisableAutoDisposeOnSceneChange()` を実装
- `OnActiveSceneChanged` で `Dispose()` を呼び出す
- `Dispose()` 内でイベント解除を実施
- 自動登録状態を保持するフラグを追加

------
https://chatgpt.com/codex/tasks/task_e_685ac9e79e9c832aa953a12d2e34c1cc