### PR TITLE
永続化設定機能の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,10 @@ SoundSystemPreset -->|SEプリセット保持| SerializedSESettingDictionary
 
 
 ## 機能のピックアップ
-### SoundSystem.cs  
-- 外部APIを集約するファサードクラス  
+### SoundSystem.cs
+- 外部APIを集約するファサードクラス
 - `CreateFromPreset` によりプリセットベースの初期化が可能
+- AudioSource用GameObjectをシーン跨ぎで保持する設定に対応
 
 ### BGMManager.cs, SEManager.cs  
 - BGMは `FadeIn`, `FadeOut`, `CrossFade` に対応  
@@ -128,7 +129,8 @@ var soundSystem = new SoundSystem(
     pool,
     listener,
     mixer,
-    mixerGroup);
+    mixerGroup,
+    true);
 soundSystem.StartAutoEvict(60f);
 //利用終了時
 soundSystem.Dispose();
@@ -137,7 +139,8 @@ soundSystem.Dispose();
 var soundSystem = SoundSystem.CreateFromPreset(
     preset,
     listener,
-    mixer);
+    mixer,
+    true);
 soundSystem.StartAutoEvict(60f);
 soundSystem.Dispose();
 ```

--- a/SoundSystemPlugin_ForUnity_Project/source/AudioSourcePool/AudioSourcePoolFactory.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/AudioSourcePool/AudioSourcePoolFactory.cs
@@ -18,12 +18,12 @@ namespace SoundSystem
         /// 指定プール管理方式に応じたIAudioSourcePoolインスタンスを生成
         /// </summary>
         public static IAudioSourcePool Create(Type type,
-            AudioMixerGroup seMixerG, int initSize, int maxSize)
+            AudioMixerGroup seMixerG, int initSize, int maxSize, bool persistent = false)
         {
             return type switch
             {
-                Type.FIFO   => new AudioSourcePool_FIFO(seMixerG, initSize, maxSize),
-                Type.Strict => new AudioSourcePool_Strict(seMixerG, initSize, maxSize),
+                Type.FIFO   => new AudioSourcePool_FIFO(seMixerG, initSize, maxSize, persistent),
+                Type.Strict => new AudioSourcePool_Strict(seMixerG, initSize, maxSize, persistent),
                 _ => throw new ArgumentOutOfRangeException(nameof(type)),
             };
         }

--- a/SoundSystemPlugin_ForUnity_Project/source/AudioSourcePool/AudioSourcePool_Base.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/AudioSourcePool/AudioSourcePool_Base.cs
@@ -18,10 +18,14 @@ namespace SoundSystem
         protected readonly int initSize;
         public IEnumerable<AudioSource> GetAllResources() => pool;
 
-        public AudioSourcePool_Base(AudioMixerGroup seMixerG, int initSize, int maxSize)
+        public AudioSourcePool_Base(AudioMixerGroup seMixerG, int initSize, int maxSize, bool persistent = false)
         {
             pool          = new();
             sourceRoot    = new("SE_AudioSources");
+            if (persistent)
+            {
+                Object.DontDestroyOnLoad(sourceRoot);
+            }
             this.maxSize  = maxSize;
             this.initSize = initSize;
             this.seMixerG = seMixerG;

--- a/SoundSystemPlugin_ForUnity_Project/source/AudioSourcePool/AudioSourcePool_FIFO.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/AudioSourcePool/AudioSourcePool_FIFO.cs
@@ -12,8 +12,8 @@ namespace SoundSystem
     internal sealed class AudioSourcePool_FIFO : AudioSourcePool_Base
     {
         public AudioSourcePool_FIFO(AudioMixerGroup mixerG, int initSize,
-            int maxSize)
-            : base(mixerG, initSize, maxSize)
+            int maxSize, bool persistent = false)
+            : base(mixerG, initSize, maxSize, persistent)
         {
         }
     

--- a/SoundSystemPlugin_ForUnity_Project/source/AudioSourcePool/AudioSourcePool_Strict.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/AudioSourcePool/AudioSourcePool_Strict.cs
@@ -12,8 +12,8 @@ namespace SoundSystem
     internal sealed class AudioSourcePool_Strict : AudioSourcePool_Base
     {
         public AudioSourcePool_Strict(AudioMixerGroup mixerG, int initSize,
-            int maxSize)
-            : base(mixerG, initSize, maxSize)
+            int maxSize, bool persistent = false)
+            : base(mixerG, initSize, maxSize, persistent)
         {
         }
     

--- a/SoundSystemPlugin_ForUnity_Project/source/BGMManager.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/BGMManager.cs
@@ -31,12 +31,16 @@ namespace SoundSystem
         private CancellationTokenSource fadeCTS;
 
         /// <param name="mixerGroup">BGM出力先のAudioMixerGroup</param>
-        public BGMManager(AudioMixerGroup mixerGroup, ISoundLoader loader)
+        public BGMManager(AudioMixerGroup mixerGroup, ISoundLoader loader, bool persistent = false)
         {
             this.loader = loader;
 
             //BGM専用AudioSourceとそれがアタッチされたGameObjectを作成
             sourceRoot = new("BGM_AudioSources");
+            if (persistent)
+            {
+                Object.DontDestroyOnLoad(sourceRoot);
+            }
             bgmSources =
             (
                 CreateSourceObj("BGMSource_0"),

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundPreset/SoundPresetProperty.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundPreset/SoundPresetProperty.cs
@@ -54,5 +54,8 @@ namespace SoundSystem
         public AudioSourcePoolFactory.Type poolType = AudioSourcePoolFactory.Type.FIFO;
         public int initSize = 5;
         public int maxSize  = 10;
+
+        [Header("永続化設定")]
+        public bool persistentGameObjects = false;
     }
 }

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundPreset/SoundPresetPropertyEditor.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundPreset/SoundPresetPropertyEditor.cs
@@ -28,6 +28,7 @@ namespace SoundSystem
         private SerializedProperty poolType;
         private SerializedProperty initSize;
         private SerializedProperty maxSize;
+        private SerializedProperty persistentGameObjects;
 
         private void OnEnable()
         {
@@ -52,6 +53,7 @@ namespace SoundSystem
             poolType = serializedObject.FindProperty("poolType");
             initSize = serializedObject.FindProperty("initSize");
             maxSize  = serializedObject.FindProperty("maxSize");
+            persistentGameObjects = serializedObject.FindProperty("persistentGameObjects");
         }
 
         public override void OnInspectorGUI()
@@ -98,6 +100,7 @@ namespace SoundSystem
             EditorGUILayout.PropertyField(poolType, true);
             EditorGUILayout.PropertyField(initSize, true);
             EditorGUILayout.PropertyField(maxSize, true);
+            EditorGUILayout.PropertyField(persistentGameObjects);
 
             serializedObject.ApplyModifiedProperties();
         }

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundSystem.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundSystem.cs
@@ -32,7 +32,7 @@ namespace SoundSystem
 
         public SoundSystem(ISoundLoader loader, ISoundCache cache, IAudioSourcePool pool,
             AudioListener listener, AudioMixer mixer, AudioMixerGroup bgmGroup,
-            bool canLogging = true)
+            bool persistent = false, bool canLogging = true)
         {
             if (canLogging)
             {
@@ -43,24 +43,32 @@ namespace SoundSystem
             this.mixer  = mixer;
             this.loader = loader;
             this.cache  = cache;
-            bgm         = new(bgmGroup, loader);
+            bgm         = new(bgmGroup, loader, persistent);
             se          = new(pool, loader);
             effector    = new(listener);
         }
 
-        public static SoundSystem CreateFromPreset(SoundPresetProperty preset, 
-            AudioListener listener, AudioMixer mixer, bool canLogging = true)
+        public static SoundSystem CreateFromPreset(SoundPresetProperty preset,
+            AudioListener listener, AudioMixer mixer, bool persistent,
+            bool canLogging = true)
         {
             var cache  = SoundCacheFactory.Create(preset.cacheType, preset.param);
             var loader = SoundLoaderFactory.Create(preset.loaderType, cache);
             var pool   = AudioSourcePoolFactory.Create(preset.poolType,
-                            preset.seMixerG, preset.initSize, preset.maxSize);
+                            preset.seMixerG, preset.initSize, preset.maxSize, persistent);
             var ss     = new SoundSystem(loader, cache, pool, listener, mixer,
-                            preset.bgmMixerG, canLogging);
+                            preset.bgmMixerG, persistent, canLogging);
             ss.bgmPresets = preset.bgmPresets;
             ss.sePresets  = preset.sePresets;
             if (preset.enableAutoEvict) ss.StartAutoEvict(preset.autoEvictInterval);
             return ss;
+        }
+
+        public static SoundSystem CreateFromPreset(SoundPresetProperty preset,
+            AudioListener listener, AudioMixer mixer, bool canLogging = true)
+        {
+            return CreateFromPreset(preset, listener, mixer,
+                preset.persistentGameObjects, canLogging);
         }
     
         public float? RetrieveMixerParameter(string exposedParamName)


### PR DESCRIPTION
## 概要
- `BGMManager` と `AudioSourcePool` の `GameObject` を `DontDestroyOnLoad` 可能に
- `SoundSystem` から永続化設定を受け取れるよう拡張
- プリセットに永続化フラグを追加し `EditorGUI` も対応
- README のサンプルコードと機能説明を更新

------
https://chatgpt.com/codex/tasks/task_e_685acd2bfd04832abd02cf37a35995a8