### PR TITLE
ライセンス情報整理

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Fukada Ryuto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Unity 上での BGM・SE 管理を一本化するためのライブラリです�
 1. UniTask と（必要に応じて）Addressables をプロジェクトに導入します。
 2. 本リポジトリをビルドして生成される `SoundSystem.dll` を `Assets/Plugins` に配置します。
 3. Addressables を利用する場合は Player Settings の `Scripting Define Symbols` に `USE_ADDRESSABLES` を追加します。
+4. 本ライブラリおよび依存ライブラリの UniTask は MIT ライセンスで公開されています。詳細は `LICENSE` と `THIRD-PARTY-LICENSE` を参照してください。
 
 ## 初期化例
 ### 手動構成
@@ -145,4 +146,8 @@ AudioSourcePool_Strict -->|継承| AudioSourcePool_Base
 SoundPresetProperty -->|BGMプリセット| SerializedBGMSettingDictionary
 SoundPresetProperty -->|SEプリセット| SerializedSESettingDictionary
 ```
+
+## ライセンス
+本リポジトリは MIT ライセンスで公開されています。詳細は [LICENSE](LICENSE) を参照してください。
+また、依存ライブラリの UniTask も MIT ライセンスで提供されています。第三者ライセンスの一覧は [THIRD-PARTY-LICENSE](THIRD-PARTY-LICENSE) を参照してください。
 

--- a/THIRD-PARTY-LICENSE
+++ b/THIRD-PARTY-LICENSE
@@ -1,0 +1,29 @@
+# THIRD-PARTY LICENSES
+
+本プロジェクトで利用しているサードパーティライブラリのライセンス情報をまとめています。
+
+## UniTask
+
+Copyright (c) 2019 Cysharp, Inc.
+
+UniTask は MIT ライセンスの下で配布されています。以下にライセンス本文を示します。
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## 概要
- UniTask のライセンスをまとめた `THIRD-PARTY-LICENSE` を追加
- README の導入方法とライセンス節を更新し，サードパーティライセンスファイルへのリンクを追記

## テスト
- `dotnet test` は `dotnet` コマンドが無く実行不可

------
https://chatgpt.com/codex/tasks/task_e_685b4b2a7148832a98fb98e8d9d9f28e