### PR TITLE
サウンドキャッシュの参照カウント機能追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Unity 上での BGM・SE 管理を一本化するためのライブラリです�
 - SoundPresetProperty：BGM・SE のプリセット設定を ScriptableObject として管理
 - ListenerEffector：AudioListener へのフィルター適用・無効化
 - オートエビクト：一定間隔でキャッシュを自動削除
+- 使用中のサウンドはキャッシュから削除しない参照カウント機能
 - オートディスポーズ：シーン変更時の自動解放を選択可能
 - ロギング：Safe / Warn / Error の 3 段階でログファイルを出力
 
@@ -145,6 +146,10 @@ AudioSourcePool_Strict -->|継承| AudioSourcePool_Base
 SoundPresetProperty -->|BGMプリセット| SerializedBGMSettingDictionary
 SoundPresetProperty -->|SEプリセット| SerializedSESettingDictionary
 ```
+
+## 既存コードへの影響
+`ISoundCache` に参照カウント用の `BeginUse` / `EndUse` が追加されました。
+既存の実装クラスを利用している場合は、これらのメソッドを適宜呼び出す必要があります。
 
 ## ライセンス
 本リポジトリは MIT ライセンスで公開されています。詳細は [LICENSE](LICENSE) を参照してください。

--- a/SoundSystemPlugin_ForUnity_Project/source/SEManager.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SEManager.cs
@@ -12,11 +12,13 @@ namespace SoundSystem
     {
         private readonly IAudioSourcePool sourcePool;
         private readonly ISoundLoader loader;
+        private readonly ISoundCache cache;
     
-        public SEManager(IAudioSourcePool sourcePool, ISoundLoader loader)
+        public SEManager(IAudioSourcePool sourcePool, ISoundLoader loader, ISoundCache cache)
         {
             this.sourcePool = sourcePool;
             this.loader     = loader;
+            this.cache      = cache;
         }
     
         /// <param name="volume">音量(0〜1)</param>
@@ -34,7 +36,8 @@ namespace SoundSystem
                 Log.Error($"Play失敗:リソース読込に失敗,{resourceAddress}");
                 return;
             }
-    
+            cache.BeginUse(resourceAddress);
+
             //AudioSourcePoolを取得
             var source = sourcePool.Retrieve();
             if (source == null)
@@ -50,6 +53,7 @@ namespace SoundSystem
             source.transform.position = position;
             source.PlayOneShot(clip);
             await UniTask.WaitWhile(() => source.isPlaying);
+            cache.EndUse(resourceAddress);
             onComplete?.Invoke();
 
             Log.Safe($"Play成功:{resourceAddress},vol = {volume},pitch = {pitch}," +

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundCache/ISoundCache.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundCache/ISoundCache.cs
@@ -5,13 +5,17 @@ namespace SoundSystem
     public interface ISoundCache
     {
         AudioClip Retrieve(string resourceAddress);
-    
+
         void Add(string resourceAddress, AudioClip clip);
     
         void Remove(string resourceAddress);
     
         void ClearAll();
-    
+
         void Evict();
+
+        void BeginUse(string resourceAddress);
+
+        void EndUse(string resourceAddress);
     }
 }

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundCache/SoundCache_LRU.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundCache/SoundCache_LRU.cs
@@ -49,10 +49,11 @@ namespace SoundSystem
         {
             var currentTime = Time.time;
             var toRemove = new List<string>();
-    
+
             foreach (var entry in lastAccessTime)
             {
-                if (currentTime - entry.Value > idleTimeThreshold)
+                if (currentTime - entry.Value > idleTimeThreshold &&
+                    (usageCount.TryGetValue(entry.Key, out var count) == false || count <= 0))
                 {
                     toRemove.Add(entry.Key);
                 }

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundCache/SoundCache_Random.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundCache/SoundCache_Random.cs
@@ -25,7 +25,16 @@ namespace SoundSystem
             }
     
             int excessCount = cache.Count - maxCacheCount;
-            var keys        = new List<string>(cache.Keys);
+            var keys = new List<string>();
+            foreach (var k in cache.Keys)
+            {
+                if (usageCount.TryGetValue(k, out var c) == false || c <= 0)
+                {
+                    keys.Add(k);
+                }
+            }
+
+            excessCount = Math.Min(excessCount, keys.Count);
     
             Log.Safe($"Evict実行:{excessCount}件削除, max = {maxCacheCount}");
             for (int i = 0; i < excessCount; i++)

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundCache/SoundCache_TTL.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundCache/SoundCache_TTL.cs
@@ -42,7 +42,8 @@ namespace SoundSystem
     
             foreach (var entry in registerTime)
             {
-                if (currentTime - entry.Value > ttlSeconds)
+                if (currentTime - entry.Value > ttlSeconds &&
+                    (usageCount.TryGetValue(entry.Key, out var count) == false || count <= 0))
                 {
                     toRemove.Add(entry.Key);
                 }

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundSystem.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundSystem.cs
@@ -43,8 +43,8 @@ namespace SoundSystem
             this.mixer  = mixer;
             this.loader = loader;
             this.cache  = cache;
-            bgm         = new(bgmGroup, loader, persistent);
-            se          = new(pool, loader);
+            bgm         = new(bgmGroup, loader, cache, persistent);
+            se          = new(pool, loader, cache);
             effector    = new(listener);
         }
 


### PR DESCRIPTION
## 変更内容
- `ISoundCache` に `BeginUse` / `EndUse` を追加
- `SoundCache_Base` で参照カウント管理を実装
- 各 `SoundCache_*` の `Evict` 処理を参照カウント考慮へ修正
- `BGMManager` と `SEManager` が再生時に `BeginUse`、終了時に `EndUse` を呼ぶよう更新
- README に新機能と互換性への注意を追記

## テスト
- `dotnet build` を試行するも実行環境に .NET SDK が無く失敗


------
https://chatgpt.com/codex/tasks/task_e_685c0ff0c3ac832ab8cc22b8f16c7b67