### PR TITLE
BGMフェード操作の修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ await soundSystem.PlayBGMWithPreset("bgm_battle", "BattlePreset");
 ```csharp
 await soundSystem.PlaySE("se_click", Vector3.zero, 1.0f, 1.0f, 1.0f);
 await soundSystem.PlaySEWithPreset("se_explosion", "ExplosionPreset");
+await soundSystem.FadeInSE("se_beam", 0.5f);
+await soundSystem.FadeOutAllSE(1.0f);
 ```
 ### Mixer パラメータ
 ```csharp

--- a/SoundSystemPlugin_ForUnity_Project/source/AudioSourceFader.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/AudioSourceFader.cs
@@ -1,0 +1,57 @@
+namespace SoundSystem
+{
+    using UnityEngine;
+    using Cysharp.Threading.Tasks;
+    using System;
+    using System.Threading;
+
+    /// <summary>
+    /// AudioSource の音量フェードを制御するユーティリティ
+    /// </summary>
+    internal sealed class AudioSourceFader : IDisposable
+    {
+        private readonly AudioSource source;
+        private CancellationTokenSource cts;
+
+        public AudioSourceFader(AudioSource source)
+        {
+            this.source = source;
+        }
+
+        public void Cancel()
+        {
+            cts?.Cancel();
+            cts?.Dispose();
+            cts = null;
+        }
+
+        public async UniTask Fade(float from, float to, float duration)
+        {
+            Cancel();
+            cts = new();
+            var token = cts.Token;
+            try
+            {
+                float startTime = Time.time;
+                while (true)
+                {
+                    if (token.IsCancellationRequested) return;
+                    float t = (Time.time - startTime) / duration;
+                    source.volume = Mathf.Lerp(from, to, t);
+                    if (t >= 1f) break;
+                    await UniTask.NextFrame(token);
+                }
+                source.volume = to;
+            }
+            catch (OperationCanceledException)
+            {
+                // フェード中断
+            }
+        }
+
+        public void Dispose()
+        {
+            Cancel();
+        }
+    }
+}

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundSystem.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundSystem.cs
@@ -202,7 +202,15 @@ namespace SoundSystem
             await se.Play(resourceAddress, volume, pitch, spatialBlend, position,
                 onComplete);
         }
-    
+
+        public async UniTask FadeInSE(string resourceAddress, float duration,
+            Vector3 position = default, float volume = 0.5f, float pitch = 1.0f,
+            float spatialBlend = 1.0f, Action onComplete = null)
+        {
+            await se.FadeIn(resourceAddress, duration, volume, pitch, spatialBlend,
+                position, onComplete);
+        }
+
         public async UniTask PlaySEWithPreset(string resourceAddress, string presetName,
             Action onComplete = null)
         {
@@ -213,7 +221,17 @@ namespace SoundSystem
                     onComplete);
             }
         }
-    
+
+        public async UniTask FadeInSEWithPreset(string resourceAddress, string presetName,
+            float duration, Action onComplete = null)
+        {
+            if (TryRetrieveSEPreset(presetName, out SoundPresetProperty.SEPreset preset))
+            {
+                await se.FadeIn(resourceAddress, duration, preset.volume, preset.pitch,
+                    preset.spatialBlend, preset.position, onComplete);
+            }
+        }
+
         public void StopAllSE()
         {
             se.StopAll();
@@ -227,6 +245,20 @@ namespace SoundSystem
         public void PauseAllSE()
         {
             se.PauseAll();
+        }
+
+        public async UniTask FadeOutAllSE(float duration, Action onComplete = null)
+        {
+            await se.FadeOutAll(duration, onComplete);
+        }
+
+        public async UniTask FadeOutAllSEWithPreset(string presetName, float duration,
+            Action onComplete = null)
+        {
+            if (TryRetrieveSEPreset(presetName, out _))
+            {
+                await se.FadeOutAll(duration, onComplete);
+            }
         }
         #endregion
     


### PR DESCRIPTION
## 概要
- `AudioSourceFader` の更新
  - `Time.time` を用いた計算に変更し `UniTask.NextFrame` で待機
- BGM クロスフェード時にフェーダーの参照入れ替えを追加

## 確認事項
- `dotnet` コマンドが無いためビルド不可

------
https://chatgpt.com/codex/tasks/task_e_685bfa01b848832a970c4aaf4fabab4f