### PR TITLE
SoundPreset検索機能の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Unity 上での BGM・SE 管理を一本化するためのライブラリです�
 - SE 再生：AudioSource プールで効率的に管理（FIFO または Strict）、FadeIn / 全体フェードアウト対応
 - SoundLoader：Addressables / Resources / Streaming から選択可能
 - SoundCache：LRU / TTL / Random の削除方式を提供
-- SoundPresetProperty：BGM・SE のプリセット設定を ScriptableObject として管理
+- SoundPresetProperty：BGM・SE のプリセット設定を ScriptableObject として管理（検索機能付き）
 - ListenerEffector：AudioListener へのフィルター適用・無効化
 - オートエビクト：一定間隔でキャッシュを自動削除
 - 使用中のサウンドはキャッシュから削除しない参照カウント機能

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundPreset/SoundPresetPropertyEditor.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundPreset/SoundPresetPropertyEditor.cs
@@ -10,10 +10,15 @@ namespace SoundSystem
         //BGM
         private SerializedProperty bgmPresets;
         private SerializedProperty bgmMixerG;
+        private SerializedProperty bgmPresetList;
 
         //SE
         private SerializedProperty sePresets;
         private SerializedProperty seMixerG;
+        private SerializedProperty sePresetList;
+
+        //検索
+        private string searchText = string.Empty;
 
         //SoundLoader設定
         private SerializedProperty loaderType;
@@ -30,15 +35,50 @@ namespace SoundSystem
         private SerializedProperty maxSize;
         private SerializedProperty persistentGameObjects;
 
+        private void DrawPresetList(SerializedProperty list, string label)
+        {
+            if (list == null)
+            {
+                return;
+            }
+
+            if (string.IsNullOrEmpty(searchText))
+            {
+                EditorGUILayout.PropertyField(list, new GUIContent(label), true);
+            }
+            else
+            {
+                EditorGUILayout.LabelField(label, EditorStyles.boldLabel);
+                for (int i = 0; i < list.arraySize; i++)
+                {
+                    SerializedProperty element = list.GetArrayElementAtIndex(i);
+                    var nameProp = element.FindPropertyRelative("presetName");
+                    if (nameProp == null)
+                    {
+                        continue;
+                    }
+                    string name = nameProp.stringValue;
+                    if (name.IndexOf(searchText, System.StringComparison.OrdinalIgnoreCase) < 0)
+                    {
+                        continue;
+                    }
+
+                    EditorGUILayout.PropertyField(element, true);
+                }
+            }
+        }
+
         private void OnEnable()
         {
             //BGM
             bgmMixerG  = serializedObject.FindProperty("bgmMixerG");
             bgmPresets = serializedObject.FindProperty("bgmPresets");
+            bgmPresetList = bgmPresets.FindPropertyRelative("presetList");
 
             //SE
             seMixerG  = serializedObject.FindProperty("seMixerG");
             sePresets = serializedObject.FindProperty("sePresets");
+            sePresetList = sePresets.FindPropertyRelative("presetList");
 
             //SoundLoader設定
             loaderType = serializedObject.FindProperty("loaderType");
@@ -60,13 +100,16 @@ namespace SoundSystem
         {
             serializedObject.Update();
 
+            searchText = EditorGUILayout.ToolbarSearchField(searchText);
+            EditorGUILayout.Space();
+
             //BGM
             EditorGUILayout.PropertyField(bgmMixerG, true);
-            EditorGUILayout.PropertyField(bgmPresets, true);
+            DrawPresetList(bgmPresetList, "BGM Presets");
 
             //SE
             EditorGUILayout.PropertyField(seMixerG, true);
-            EditorGUILayout.PropertyField(sePresets, true);
+            DrawPresetList(sePresetList, "SE Presets");
 
             //SoundLoader設定
             EditorGUILayout.PropertyField(loaderType, true);


### PR DESCRIPTION
## 変更内容
- SoundPresetPropertyEditor へ検索フィールドを追加し、BGM/SE プリセットをフィルタ表示できるようにしました
- README に検索機能対応の記述を追加

## テスト結果
- `dotnet build` は環境上 `command not found` のため未実行


------
https://chatgpt.com/codex/tasks/task_e_685cbc9ec4f4832a9ce5ba4191c1e0ca