### PR TITLE
Listenerエフェクトプリセット機能の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ soundSystem.ApplyEffectFilter<AudioReverbFilter>(f => f.reverbLevel = 1000f);
 soundSystem.DisableAllEffectFilter();
 ```
 
+### Listenerエフェクトプリセット設定
+`SoundPresetProperty` の `listenerPresets` にフィルター設定を登録しておくと、
+`SoundSystem.CreateFromPreset` 実行時に自動で適用されます。
+
 ## システム構成
 ```mermaid
 graph

--- a/SoundSystemPlugin_ForUnity_Project/source/ListenerEffector.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/ListenerEffector.cs
@@ -61,6 +61,27 @@ namespace SoundSystem
             configure?.Invoke(filter);
         }
 
+        public void ApplyFilter(Behaviour template)
+        {
+            if (template == null) return;
+
+            var type = template.GetType();
+            Log.Safe($"ApplyFilter実行:{type.Name}");
+            if (filterDict.TryGetValue(type, out var component) == false)
+            {
+                component = Listener.gameObject.AddComponent(type);
+                filterDict[type] = component;
+            }
+
+            var json = JsonUtility.ToJson(template);
+            JsonUtility.FromJsonOverwrite(json, component);
+
+            if (component is Behaviour b)
+            {
+                b.enabled = true;
+            }
+        }
+
         public void DisableFilter<FilterT>() where FilterT : Behaviour
         {
             Log.Safe($"DisableFilter実行:{typeof(FilterT).Name}");

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundPreset/SerializedListenerPresetDictionary.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundPreset/SerializedListenerPresetDictionary.cs
@@ -1,0 +1,14 @@
+namespace SoundSystem
+{
+    /// <summary>
+    /// Listenerエフェクトプリセット群を保持するクラス
+    /// </summary>
+    [System.Serializable]
+    public sealed class SerializedListenerPresetDictionary : SerializedPresetDictionary<SoundPresetProperty.ListenerEffectPreset>
+    {
+        protected override string GetPresetName(SoundPresetProperty.ListenerEffectPreset preset)
+        {
+            return preset.presetName;
+        }
+    }
+}

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundPreset/SerializedPresetDictionary.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundPreset/SerializedPresetDictionary.cs
@@ -14,6 +14,7 @@ namespace SoundSystem
     public abstract class SerializedPresetDictionary<TPreset> : ISerializationCallbackReceiver
     {
         [SerializeField] private List<TPreset>  presetList = new();
+        public IReadOnlyList<TPreset> Presets => presetList;
         private readonly Dictionary<string, TPreset> presetDict = new();
 
         /// <summary>

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundPreset/SoundPresetProperty.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundPreset/SoundPresetProperty.cs
@@ -28,6 +28,13 @@ namespace SoundSystem
             [Range(0f, 1f)] public float fadeOutDuration;
         }
 
+        [System.Serializable]
+        public struct ListenerEffectPreset
+        {
+            public string   presetName;
+            public Behaviour filter;
+        }
+
         [Header("BGM")]
         public AudioMixerGroup bgmMixerG;
         public SerializedBGMPresetDictionary bgmPresets = new();
@@ -35,6 +42,9 @@ namespace SoundSystem
         [Header("SE")]
         public AudioMixerGroup seMixerG;
         public SerializedSEPresetDictionary sePresets = new();
+
+        [Header("Listener Effect Preset")]
+        public SerializedListenerPresetDictionary listenerPresets = new();
 
         [Header("SoundLoader")]
 #if USE_ADDRESSABLES

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundPreset/SoundPresetPropertyEditor.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundPreset/SoundPresetPropertyEditor.cs
@@ -23,6 +23,12 @@ namespace SoundSystem
         private ToolbarSearchField seSearchField;
         private ScrollView seScrollView;
 
+        //Listener Effect
+        private SerializedProperty listenerPresetList;
+        private Label listenerSearchState;
+        private ToolbarSearchField listenerSearchField;
+        private ScrollView listenerScrollView;
+
         //SoundLoader設定
         private SerializedProperty loaderType;
 
@@ -53,6 +59,10 @@ namespace SoundSystem
             seMixerG      = serializedObject.FindProperty("seMixerG");
             sePresetList  = serializedObject.FindProperty("sePresets")
                                 .FindPropertyRelative("presetList");
+
+            //Listener Effect
+            listenerPresetList = serializedObject.FindProperty("listenerPresets")
+                                   .FindPropertyRelative("presetList");
 
             //SoundLoader設定
             loaderType = serializedObject.FindProperty("loaderType");
@@ -107,6 +117,22 @@ namespace SoundSystem
             root.Add(new Label("SE Presets"));
             root.Add(seSearchContainer);
             root.Add(seScrollView);
+
+            //Listener Effect 要素作成
+            listenerSearchField = new ToolbarSearchField();
+            listenerSearchField.RegisterValueChangedCallback(_ => RefreshPresetViews());
+            listenerSearchState = new Label("Searching");
+            listenerSearchState.style.unityFontStyleAndWeight = FontStyle.Bold;
+            listenerSearchState.style.display                 = DisplayStyle.None;
+            listenerScrollView = new ScrollView();
+            var listenerSearchContainer = new VisualElement();
+            listenerSearchContainer.style.flexDirection = FlexDirection.Column;
+            listenerSearchContainer.Add(listenerSearchField);
+            listenerSearchContainer.Add(listenerSearchState);
+            //要素作成
+            root.Add(new Label("Listener Effect Presets"));
+            root.Add(listenerSearchContainer);
+            root.Add(listenerScrollView);
 
             //SoundLoader 要素作成, 登録
             root.Add(new PropertyField(loaderType));
@@ -169,9 +195,11 @@ namespace SoundSystem
         {
             string bgmFilter = bgmSearchField?.value ?? string.Empty;
             string seFilter  = seSearchField?.value ?? string.Empty;
+            string listenerFilter = listenerSearchField?.value ?? string.Empty;
 
             FillPresetScroll(bgmScrollView, bgmPresetList, "BGM Preset", bgmFilter);
             FillPresetScroll(seScrollView, sePresetList, "SE Preset", seFilter);
+            FillPresetScroll(listenerScrollView, listenerPresetList, "Listener Preset", listenerFilter);
 
             //検索バーへの入力があれば SearchState ラベルを表示する
             if (string.IsNullOrEmpty(bgmFilter) == false)
@@ -185,6 +213,12 @@ namespace SoundSystem
                 seSearchState.style.display = DisplayStyle.Flex;
             }
             else seSearchState.style.display = DisplayStyle.None;
+
+            if (string.IsNullOrEmpty(listenerFilter) == false)
+            {
+                listenerSearchState.style.display = DisplayStyle.Flex;
+            }
+            else listenerSearchState.style.display = DisplayStyle.None;
         }
 
         private void FillPresetScroll(ScrollView target, SerializedProperty list,

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundSystem.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundSystem.cs
@@ -14,8 +14,9 @@ namespace SoundSystem
     /// </summary>
     public sealed class SoundSystem : IDisposable
     {
-        private SerializedBGMPresetDictionary bgmPresets;
-        private SerializedSEPresetDictionary  sePresets;
+        private SerializedBGMPresetDictionary      bgmPresets;
+        private SerializedSEPresetDictionary       sePresets;
+        private SerializedListenerPresetDictionary listenerPresets;
 
         private readonly BGMManager bgm;
         private readonly SEManager  se;
@@ -58,8 +59,13 @@ namespace SoundSystem
                             preset.seMixerG, preset.initSize, preset.maxSize, persistent);
             var ss     = new SoundSystem(loader, cache, pool, listener, mixer,
                             preset.bgmMixerG, persistent, canLogging);
-            ss.bgmPresets = preset.bgmPresets;
-            ss.sePresets  = preset.sePresets;
+            ss.bgmPresets      = preset.bgmPresets;
+            ss.sePresets       = preset.sePresets;
+            ss.listenerPresets = preset.listenerPresets;
+            foreach (var lp in ss.listenerPresets.Presets)
+            {
+                ss.effector.ApplyFilter(lp.filter);
+            }
             if (preset.enableAutoEvict) ss.StartAutoEvict(preset.autoEvictInterval);
             return ss;
         }


### PR DESCRIPTION
## 概要
- ListenerEffectPreset 構造体を追加し、プリセットから AudioListener へのフィルター設定を保持可能に
- 複数プリセットを扱う SerializedListenerPresetDictionary を新設
- SoundPresetPropertyEditor で Listener エフェクトプリセットの検索・編集が可能に
- SoundSystem.CreateFromPreset でプリセットを適用し初期化時に自動反映
- README に Listener エフェクトプリセット設定の説明を追記

------
https://chatgpt.com/codex/tasks/task_e_68636274f514832aa004a6b3237d4ab0