### PR TITLE
ListenerEffectPreset にフィルタータイプ追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ soundSystem.DisableAllEffectFilter();
 ### Listenerエフェクトプリセット設定
 `SoundPresetProperty` の `listenerPresets` にフィルター設定を登録しておくと、
 `SoundSystem.CreateFromPreset` 実行時に自動で適用されます。
+フィルターの種類は `ListenerEffectFilterType` から選択します。
 
 ## システム構成
 ```mermaid

--- a/SoundSystemPlugin_ForUnity_Project/source/ListenerEffectFilterType.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/ListenerEffectFilterType.cs
@@ -1,0 +1,16 @@
+namespace SoundSystem
+{
+    /// <summary>
+    /// AudioListener へ適用可能なエフェクトフィルターの種類
+    /// </summary>
+    public enum ListenerEffectFilterType
+    {
+        None,
+        AudioChorusFilter,
+        AudioDistortionFilter,
+        AudioEchoFilter,
+        AudioHighPassFilter,
+        AudioLowPassFilter,
+        AudioReverbFilter,
+    }
+}

--- a/SoundSystemPlugin_ForUnity_Project/source/ListenerEffector.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/ListenerEffector.cs
@@ -61,6 +61,46 @@ namespace SoundSystem
             configure?.Invoke(filter);
         }
 
+        public void ApplyFilter(ListenerEffectFilterType type, Behaviour template = null)
+        {
+            if (type == ListenerEffectFilterType.None) return;
+
+            var filterClass = GetFilterClass(type);
+            if (filterClass == null) return;
+
+            Log.Safe($"ApplyFilter実行:{filterClass.Name}");
+            if (filterDict.TryGetValue(filterClass, out var component) == false)
+            {
+                component = Listener.gameObject.AddComponent(filterClass);
+                filterDict[filterClass] = component;
+            }
+
+            if (template != null)
+            {
+                var json = JsonUtility.ToJson(template);
+                JsonUtility.FromJsonOverwrite(json, component);
+            }
+
+            if (component is Behaviour b)
+            {
+                b.enabled = true;
+            }
+        }
+
+        private Type GetFilterClass(ListenerEffectFilterType type)
+        {
+            return type switch
+            {
+                ListenerEffectFilterType.AudioChorusFilter      => typeof(AudioChorusFilter),
+                ListenerEffectFilterType.AudioDistortionFilter  => typeof(AudioDistortionFilter),
+                ListenerEffectFilterType.AudioEchoFilter        => typeof(AudioEchoFilter),
+                ListenerEffectFilterType.AudioHighPassFilter    => typeof(AudioHighPassFilter),
+                ListenerEffectFilterType.AudioLowPassFilter     => typeof(AudioLowPassFilter),
+                ListenerEffectFilterType.AudioReverbFilter      => typeof(AudioReverbFilter),
+                _ => null,
+            };
+        }
+
         public void ApplyFilter(Behaviour template)
         {
             if (template == null) return;

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundPreset/SoundPresetProperty.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundPreset/SoundPresetProperty.cs
@@ -31,8 +31,9 @@ namespace SoundSystem
         [System.Serializable]
         public struct ListenerEffectPreset
         {
-            public string   presetName;
-            public Behaviour filter;
+            public string                   presetName;
+            public ListenerEffectFilterType filterType;
+            public Behaviour               template;
         }
 
         [Header("BGM")]

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundSystem.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundSystem.cs
@@ -64,7 +64,7 @@ namespace SoundSystem
             ss.listenerPresets = preset.listenerPresets;
             foreach (var lp in ss.listenerPresets.Presets)
             {
-                ss.effector.ApplyFilter(lp.filter);
+                ss.effector.ApplyFilter(lp.filterType, lp.template);
             }
             if (preset.enableAutoEvict) ss.StartAutoEvict(preset.autoEvictInterval);
             return ss;


### PR DESCRIPTION
## 概要
- ListenerEffectPreset にフィルタータイプを追加して選択式に
- 選択タイプからフィルターを生成する処理を ListenerEffector に実装
- プリセット読み込み時に新しい API を利用
- README 更新

------
https://chatgpt.com/codex/tasks/task_e_6863675c103c832aa9e381482028291e