### PR TITLE
ListenerEffectPresetDrawer の UI Toolkit 対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,10 @@ soundSystem.DisableAllEffectFilter();
 ### Listenerエフェクトプリセット設定
 `SoundPresetProperty` の `listenerPresets` にフィルター設定を登録しておくと、
 `SoundSystem.CreateFromPreset` 実行時に自動で適用されます。
-フィルターの種類は `ListenerEffectFilterType` から選択します。
+フィルターの種類は `FilterKind` から選択し、
+選択したフィルターに応じた項目がインスペクター上で表示されます。
+プリセット一覧上で各フィルターの詳細を直接編集できるため、
+別Assetを開かなくても設定が完結します。
 
 ## システム構成
 ```mermaid

--- a/SoundSystemPlugin_ForUnity_Project/source/ListenerEffectPreset/Editor/ListenerEffectPresetEditor.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/ListenerEffectPreset/Editor/ListenerEffectPresetEditor.cs
@@ -1,0 +1,67 @@
+#if UNITY_EDITOR
+namespace SoundSystem
+{
+    using System;
+    using UnityEditor;
+    using UnityEditor.UIElements;
+    using UnityEngine;
+    using UnityEngine.UIElements;
+
+    [CustomPropertyDrawer(typeof(ListenerEffectPreset))]
+    internal sealed class ListenerEffectPresetDrawer : PropertyDrawer
+    {
+        public override VisualElement CreatePropertyGUI(SerializedProperty property)
+        {
+            var root = new VisualElement();
+
+            var nameProp     = property.FindPropertyRelative("presetName");
+            var kindProp     = property.FindPropertyRelative("kind");
+            var settingsProp = property.FindPropertyRelative("settings");
+
+            var nameField = new PropertyField(nameProp);
+            var kindField = new PropertyField(kindProp);
+            var settingsField = new PropertyField(settingsProp);
+
+            kindField.RegisterValueChangeCallback(_ =>
+            {
+                AssignSettingInstance(settingsProp, (FilterKind)kindProp.enumValueIndex);
+                settingsField.Bind(property.serializedObject);
+            });
+
+            root.Add(nameField);
+            root.Add(kindField);
+            root.Add(settingsField);
+
+            // 初期状態の設定インスタンスを適用
+            AssignSettingInstance(settingsProp, (FilterKind)kindProp.enumValueIndex);
+
+            return root;
+        }
+
+        private static void AssignSettingInstance(SerializedProperty settings, FilterKind k)
+        {
+            Type type = k switch
+            {
+                FilterKind.AudioChorusFilter     => typeof(ChorusFilterSettings),
+                FilterKind.AudioDistortionFilter => typeof(DistortionFilterSettings),
+                FilterKind.AudioEchoFilter       => typeof(EchoFilterSettings),
+                FilterKind.AudioHighPassFilter   => typeof(HighPassFilterSettings),
+                FilterKind.AudioLowPassFilter    => typeof(LowPassFilterSettings),
+                FilterKind.AudioReverbFilter     => typeof(ReverbFilterSettings),
+                _ => null,
+            };
+
+            if (type == null)
+            {
+                settings.managedReferenceValue = null;
+                return;
+            }
+
+            if (settings.managedReferenceValue == null || settings.managedReferenceValue.GetType() != type)
+            {
+                settings.managedReferenceValue = Activator.CreateInstance(type);
+            }
+        }
+    }
+}
+#endif

--- a/SoundSystemPlugin_ForUnity_Project/source/ListenerEffectPreset/ListenerEffectPreset.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/ListenerEffectPreset/ListenerEffectPreset.cs
@@ -1,0 +1,19 @@
+namespace SoundSystem
+{
+    using UnityEngine;
+    /// <summary>
+    /// AudioListener へ適用するエフェクトプリセット
+    /// </summary>
+    [System.Serializable]
+    public struct ListenerEffectPreset
+    {
+        public string presetName;
+        public FilterKind kind;
+        [UnityEngine.SerializeReference] public ListenerFilterSettings settings;
+
+        public void ApplyTo(ListenerEffector effector)
+        {
+            settings?.Apply(effector);
+        }
+    }
+}

--- a/SoundSystemPlugin_ForUnity_Project/source/ListenerEffectPreset/ListenerFilterSettings.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/ListenerEffectPreset/ListenerFilterSettings.cs
@@ -1,0 +1,118 @@
+namespace SoundSystem
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// AudioListener用フィルター設定の基底クラス
+    /// </summary>
+    public abstract class ListenerFilterSettings
+    {
+        public abstract void Apply(ListenerEffector effector);
+    }
+
+    [System.Serializable]
+    public sealed class ChorusFilterSettings : ListenerFilterSettings
+    {
+        [Range(0f, 1f)] public float dryMix = 0.5f;
+        [Range(0f, 1f)] public float wetMix1 = 0.5f;
+        [Range(0f, 1f)] public float wetMix2 = 0.5f;
+        [Range(0f, 1f)] public float wetMix3 = 0.5f;
+        [Range(0f, 100f)] public float delay = 40f;
+        [Range(0f, 20f)] public float rate = 0.8f;
+        [Range(0f, 1f)] public float depth = 0.03f;
+
+        public override void Apply(ListenerEffector effector)
+        {
+            effector.ApplyFilter<AudioChorusFilter>(f =>
+            {
+                f.dryMix = dryMix;
+                f.wetMix1 = wetMix1;
+                f.wetMix2 = wetMix2;
+                f.wetMix3 = wetMix3;
+                f.delay = delay;
+                f.rate = rate;
+                f.depth = depth;
+            });
+        }
+    }
+
+    [System.Serializable]
+    public sealed class DistortionFilterSettings : ListenerFilterSettings
+    {
+        [Range(0f, 1f)] public float distortionLevel = 0f;
+
+        public override void Apply(ListenerEffector effector)
+        {
+            effector.ApplyFilter<AudioDistortionFilter>(f =>
+            {
+                f.distortionLevel = distortionLevel;
+            });
+        }
+    }
+
+    [System.Serializable]
+    public sealed class EchoFilterSettings : ListenerFilterSettings
+    {
+        [Range(10f, 5000f)] public float delay = 500f;
+        [Range(0f, 1f)] public float decayRatio = 0.5f;
+        [Range(0f, 1f)] public float dryMix = 1f;
+        [Range(0f, 1f)] public float wetMix = 1f;
+
+        public override void Apply(ListenerEffector effector)
+        {
+            effector.ApplyFilter<AudioEchoFilter>(f =>
+            {
+                f.delay = delay;
+                f.decayRatio = decayRatio;
+                f.dryMix = dryMix;
+                f.wetMix = wetMix;
+            });
+        }
+    }
+
+    [System.Serializable]
+    public sealed class HighPassFilterSettings : ListenerFilterSettings
+    {
+        [Range(10f, 22000f)] public float cutoffFrequency = 5000f;
+        [Range(1f, 10f)] public float resonanceQ = 1f;
+
+        public override void Apply(ListenerEffector effector)
+        {
+            effector.ApplyFilter<AudioHighPassFilter>(f =>
+            {
+                f.cutoffFrequency = cutoffFrequency;
+                f.highpassResonanceQ = resonanceQ;
+            });
+        }
+    }
+
+    [System.Serializable]
+    public sealed class LowPassFilterSettings : ListenerFilterSettings
+    {
+        [Range(10f, 22000f)] public float cutoffFrequency = 5000f;
+        [Range(1f, 10f)] public float resonanceQ = 1f;
+
+        public override void Apply(ListenerEffector effector)
+        {
+            effector.ApplyFilter<AudioLowPassFilter>(f =>
+            {
+                f.cutoffFrequency = cutoffFrequency;
+                f.lowpassResonanceQ = resonanceQ;
+            });
+        }
+    }
+
+    [System.Serializable]
+    public sealed class ReverbFilterSettings : ListenerFilterSettings
+    {
+        public AudioReverbPreset reverbPreset = AudioReverbPreset.Off;
+
+        public override void Apply(ListenerEffector effector)
+        {
+            effector.ApplyFilter<AudioReverbFilter>(f =>
+            {
+                f.reverbPreset = reverbPreset;
+            });
+        }
+    }
+}

--- a/SoundSystemPlugin_ForUnity_Project/source/ListenerEffector.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/ListenerEffector.cs
@@ -99,6 +99,12 @@ namespace SoundSystem
             if (comp is Behaviour b) b.enabled = true;
         }
 
+        public void ApplyPreset(ListenerEffectPreset preset)
+        {
+            Log.Safe($"ApplyPreset実行:{preset.presetName}");
+            preset.ApplyTo(this);
+        }
+
         private Type GetFilterClass(FilterKind type)
         {
             return type switch

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundPreset/SerializedListenerPresetDictionary.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundPreset/SerializedListenerPresetDictionary.cs
@@ -4,9 +4,9 @@ namespace SoundSystem
     /// Listenerエフェクトプリセット群を保持するクラス
     /// </summary>
     [System.Serializable]
-    public sealed class SerializedListenerPresetDictionary : SerializedPresetDictionary<SoundPresetProperty.ListenerEffectPreset>
+    public sealed class SerializedListenerPresetDictionary : SerializedPresetDictionary<ListenerEffectPreset>
     {
-        protected override string GetPresetName(SoundPresetProperty.ListenerEffectPreset preset)
+        protected override string GetPresetName(ListenerEffectPreset preset)
         {
             return preset.presetName;
         }

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundPreset/SoundPresetProperty.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundPreset/SoundPresetProperty.cs
@@ -28,13 +28,6 @@ namespace SoundSystem
             [Range(0f, 1f)] public float fadeOutDuration;
         }
 
-        [System.Serializable]
-        public struct ListenerEffectPreset
-        {
-            public string     presetName;
-            public FilterKind kind;
-            public Behaviour  template;
-        }
 
         [Header("BGM")]
         public AudioMixerGroup bgmMixerG;

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundSystem.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundSystem.cs
@@ -64,7 +64,7 @@ namespace SoundSystem
             ss.listenerPresets = preset.listenerPresets;
             foreach (var lp in ss.listenerPresets.Presets)
             {
-                ss.effector.ApplyFilter(lp.kind, lp.template);
+                ss.effector.ApplyPreset(lp);
             }
             if (preset.enableAutoEvict) ss.StartAutoEvict(preset.autoEvictInterval);
             return ss;


### PR DESCRIPTION
## Summary
- ListenerEffectPresetDrawer を PropertyDrawer の UIToolkit 版へ変更
- フィルター種別変更時に設定クラスを自動生成

## Testing
- `dotnet build SoundSystemPlugin_ForUnity_Project/SoundSystemPlugin_ForUnity_Project.csproj -nologo` *(failed: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68648ae86bd4832aadb8cf9253b61d3c