### PR TITLE
フェード中断機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 Unity 上での BGM・SE 管理を一本化するためのライブラリです。プリセットによる設定管理、AudioSource プール、複数方式のキャッシュ、ログ出力などを備え、ゲーム内のサウンド制御をシンプルにします。
 
 ## 主な機能
-- BGM 再生：FadeIn / FadeOut / CrossFade に対応
-- SE 再生：AudioSource プールで効率的に管理（FIFO または Strict）、FadeIn / 全体フェードアウト対応
+- BGM 再生：FadeIn / FadeOut / CrossFade に対応、フェード処理の中断が可能
+- SE 再生：AudioSource プールで効率的に管理（FIFO または Strict）、FadeIn / 全体フェードアウト対応、フェード処理の中断
 - SoundLoader：Addressables / Resources / Streaming から選択可能
 - SoundCache：LRU / TTL / Random の削除方式を提供
 - SoundPresetProperty：BGM・SE のプリセット設定を ScriptableObject として管理（検索機能付き）
@@ -61,6 +61,7 @@ await soundSystem.PlayBGM("bgm_title", 1.0f);
 await soundSystem.FadeInBGM("bgm_intro", 2.0f, 1.0f);
 await soundSystem.CrossFadeBGM("bgm_battle", 2.0f);
 await soundSystem.PlayBGMWithPreset("bgm_battle", "BattlePreset");
+soundSystem.InterruptBGMFade();
 ```
 ### SE
 ```csharp
@@ -69,6 +70,7 @@ await soundSystem.PlaySEWithPreset("se_explosion", "ExplosionPreset");
 await soundSystem.FadeInSE("se_wind", 1.5f);
 await soundSystem.FadeOutAllSE(1.0f);
 await soundSystem.FadeInSEWithPreset("se_magic", "MagicPreset");
+soundSystem.InterruptAllSEFade();
 ```
 ### Mixer パラメータ
 ```csharp

--- a/SoundSystemPlugin_ForUnity_Project/source/SEManager.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SEManager.cs
@@ -115,6 +115,14 @@ namespace SoundSystem
             }
         }
 
+        public void InterruptAllFade()
+        {
+            foreach (var cts in fadeCtsMap.Values)
+            {
+                cts.Cancel();
+            }
+        }
+
         public async UniTask FadeIn(string resourceAddress, float duration,
             float volume, float pitch, float spatialBlend, Vector3 position,
             Action onComplete = null)

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundSystem.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundSystem.cs
@@ -154,6 +154,11 @@ namespace SoundSystem
         {
             bgm.Pause();
         }
+
+        public void InterruptBGMFade()
+        {
+            bgm.InterruptFade();
+        }
     
         public async UniTask FadeInBGM(string resourceAddress, float duration,
             float volume = 1.0f, Action onComplete = null)
@@ -257,6 +262,11 @@ namespace SoundSystem
         public void PauseAllSE()
         {
             se.PauseAll();
+        }
+
+        public void InterruptAllSEFade()
+        {
+            se.InterruptAllFade();
         }
         #endregion
     


### PR DESCRIPTION
## 概要
- BGM, SE のフェード処理を途中で停止できる API を追加
- BGMManager, SEManager にクロスフェード中断処理を実装, SoundSystem から利用できるラッパーを追加
- README に機能説明とサンプルコードを追記

------
https://chatgpt.com/codex/tasks/task_e_68653d424a50832a89c9592ebd381513