### PR TITLE
AudioSourcePool の取得処理共通化

### DIFF
--- a/SoundSystemPlugin_ForUnity_Project/source/AudioSourcePool/AudioSourcePool_FIFO.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/AudioSourcePool/AudioSourcePool_FIFO.cs
@@ -5,9 +5,7 @@ namespace SoundSystem
     
     /// <summary>
     /// SE向けにAudioSourceをプールで管理するクラス<para></para>
-    /// - 未使用のAudioSourceがあればそれを返す<para></para>
-    /// - 全て使用中で最大サイズなら最古のものを再利用<para></para>
-    /// - 全て使用中で最大サイズ未満なら新規作成したものを返す
+    /// - 未使用の AudioSource がなければプールの最古を再利用
     /// </summary>
     internal sealed class AudioSourcePool_FIFO : AudioSourcePool_Base
     {
@@ -17,37 +15,12 @@ namespace SoundSystem
         {
         }
     
-        public override AudioSource Retrieve()
+        protected override AudioSource RetrieveWhenPoolFull()
         {
-            Log.Safe("Retrieve実行");
-    
-            //未使用のAudioSourceがあれば、それを返す
-            for (int i = 0; i < pool.Count; i++)
-            {
-                var source = pool.Dequeue();
-                if (source.isPlaying == false)
-                {
-                    pool.Enqueue(source);
-                    return source;
-                }
-    
-                pool.Enqueue(source);
-            }
-    
-            //プールが最大サイズの場合、最古のものを再利用
-            if (pool.Count >= maxSize)
-            {
-                var oldest = pool.Dequeue();
-                oldest.Stop();
-                pool.Enqueue(oldest);
-                return oldest;
-            }
-            else //最大サイズ未満なら新規作成
-            {
-                var created = CreateSourceWithOwnerGameObject();
-                pool.Enqueue(created);
-                return created;
-            }
+            var oldest = pool.Dequeue();
+            oldest.Stop();
+            pool.Enqueue(oldest);
+            return oldest;
         }
     }
 }

--- a/SoundSystemPlugin_ForUnity_Project/source/AudioSourcePool/AudioSourcePool_Strict.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/AudioSourcePool/AudioSourcePool_Strict.cs
@@ -5,9 +5,7 @@ namespace SoundSystem
     
     /// <summary>
     /// SE向けにAudioSourceをプールで管理するクラス<para></para>
-    /// - 未使用のAudioSourceがあればそれを返す<para></para>
-    /// - 全て使用中で最大サイズ未満なら新規作成したものを返す<para></para>
-    /// - 全て使用中で最大サイズならnullを返す
+    /// - 未使用の AudioSource がなく、プールが埋まっていれば null を返す
     /// </summary>
     internal sealed class AudioSourcePool_Strict : AudioSourcePool_Base
     {
@@ -17,31 +15,8 @@ namespace SoundSystem
         {
         }
     
-        public override AudioSource Retrieve()
+        protected override AudioSource RetrieveWhenPoolFull()
         {
-            Log.Safe("Retrieve実行");
-    
-            //未使用のAudioSourceがあれば、それを返す
-            for (int i = 0; i < pool.Count; i++)
-            {
-                var source = pool.Dequeue();
-                if (source.isPlaying == false)
-                {
-                    pool.Enqueue(source);
-                    return source;
-                }
-    
-                pool.Enqueue(source);
-            }
-    
-            //プールが最大サイズ未満なら新規作成したものを返す
-            //最大サイズで全て使用中ならnull
-            if (pool.Count < maxSize)
-            {
-                var created = CreateSourceWithOwnerGameObject();
-                pool.Enqueue(created);
-                return created;
-            }
             return null;
         }
     }


### PR DESCRIPTION
## 変更内容
- `AudioSourcePool_Base` に未使用 `AudioSource` を返す共通処理を実装
- `AudioSourcePool_FIFO` / `AudioSourcePool_Strict` はプール満杯時の挙動のみを実装
- 上記に伴うコメント更新

## 確認事項
- `dotnet` コマンドが存在しないためビルド確認は行えていません

------
https://chatgpt.com/codex/tasks/task_e_6866a866ea90832a96157bccbf1ef345