### PR TITLE
SoundCache 機能追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ soundSystem.ApplyEffectFilter<AudioReverbFilter>(f => f.reverbLevel = 1000f);
 soundSystem.DisableAllEffectFilter();
 ```
 
+### キャッシュ状況の確認
+```csharp
+int count = cache.Count;
+foreach (var key in cache.Keys)
+{
+    Debug.Log($"Cached:{key}");
+}
+```
+
 ### Listenerエフェクトプリセット設定
 `SoundPresetProperty` の `listenerPresets` にフィルター設定を登録しておくと、
 `SoundSystem.CreateFromPreset` 実行時に自動で適用されます。
@@ -167,7 +176,8 @@ SoundPresetProperty -->|Listenerエフェクトプリセット| SerializedListen
 
 ## 既存コードへの影響
 `ISoundCache` に参照カウント用の `BeginUse` / `EndUse` が追加されました。
-既存の実装クラスを利用している場合は、これらのメソッドを適宜呼び出す必要があります。
+加えて、キャッシュ件数を取得する `Count` プロパティと、登録キーを列挙する `Keys` プロパティを実装しました。
+既存の実装クラスを利用している場合は、これらのメンバーを適宜利用してください。
 
 ## ライセンス
 本リポジトリは MIT ライセンスで公開されています。詳細は [LICENSE](LICENSE) を参照してください。

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundCache/ISoundCache.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundCache/ISoundCache.cs
@@ -1,9 +1,14 @@
 namespace SoundSystem
 {
+    using System.Collections.Generic;
     using UnityEngine;
     
     public interface ISoundCache
     {
+        int Count { get; }
+
+        IEnumerable<string> Keys { get; }
+
         AudioClip Retrieve(string resourceAddress);
 
         void Add(string resourceAddress, AudioClip clip);

--- a/SoundSystemPlugin_ForUnity_Project/source/SoundCache/SoundCache.cs
+++ b/SoundSystemPlugin_ForUnity_Project/source/SoundCache/SoundCache.cs
@@ -14,6 +14,10 @@ namespace SoundSystem
         private readonly IEvictionStrategy strategy;
         private ISoundLoader loader;
 
+        public int Count => cache.Count;
+
+        public IEnumerable<string> Keys => cache.Keys;
+
         internal SoundCache(IEvictionStrategy s)
         {
             strategy = s;


### PR DESCRIPTION
## 概要
- SoundCache のキャッシュ数取得とキー列挙をサポート
- デバッグ向けのキャッシュ確認例を README に追加

## 変更内容
- `ISoundCache` に `Count` と `Keys` を定義
- `SoundCache` で上記プロパティを実装
- README に使用例と仕様追加の説明を記載

## 確認事項
- テストやビルドは環境の都合で未実施

------
https://chatgpt.com/codex/tasks/task_e_6868cb9eeae0832a929376ed5d854de9